### PR TITLE
Fix library selection

### DIFF
--- a/99-opera-fix
+++ b/99-opera-fix
@@ -1,0 +1,2 @@
+DPkg::Post-Invoke {"/home/<USER>/dev/opera-fix-ffmpeg/opera-fix-ffmpeg.sh";};
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Fix for Opera's FFMPEG in Linux
+The script was fixed to correctly link the latest version of the library.
+One of the exit codes was changed from 1 to 0 so that it does not interfere
+with apt post-invoke actions if configured.
+
+The 99-opera-fix file can be put directly into /etc/apt/apt.conf.d after
+changing it to reflect the correct path where the script is available.
+
 

--- a/opera-fix-ffmpeg.sh
+++ b/opera-fix-ffmpeg.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
-# See: https://forums.opera.com/topic/37539/solving-the-problem-of-the-opera-browser-with-video-playback-in-ubuntu-and-similar-distributions-linux-mint-kde-neon/
-
-#echo "Warning: This script reportedly breaks recent version of Opera browser. Proceed with caution."
-#echo "However, files are backed up before changing, so you can always restore"
-#echo "Script will automatically proceed in 10 seconds. Press CTRL-C to cancel."
-#sleep 10
-
-# default installation path of Opera using their .deb file
+# default installation path of Opera using their .deb file on Pop!_OS
 OPERA_PATH="${1:-/usr/lib/x86_64-linux-gnu/opera}"
 SNAP_BINARY="${2:-/usr/bin/snap}"
 

--- a/opera-fix-ffmpeg.sh
+++ b/opera-fix-ffmpeg.sh
@@ -30,6 +30,8 @@ fi
 
 if validate_symlink "${OPERA_PATH}"; then
   echo "Symlink is already up to date. Nothing to do."
+# setting exit code to 0 so that the script does not create issues with apt post operations if automated
+# also, why would you set this to non-zero? This is a correct behaviour...
   exit 0
 fi
 

--- a/opera-fix-ffmpeg.sh
+++ b/opera-fix-ffmpeg.sh
@@ -30,7 +30,7 @@ fi
 
 if validate_symlink "${OPERA_PATH}"; then
   echo "Symlink is already up to date. Nothing to do."
-  exit 1
+  exit 0
 fi
 
 # Elevate privileges if possible. Required.

--- a/opera-fix-ffmpeg.sh
+++ b/opera-fix-ffmpeg.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # See: https://forums.opera.com/topic/37539/solving-the-problem-of-the-opera-browser-with-video-playback-in-ubuntu-and-similar-distributions-linux-mint-kde-neon/
 
-echo "Warning: This script reportedly breaks recent version of Opera browser. Proceed with caution."
-echo "However, files are backed up before changing, so you can always restore"
-echo "Script will automatically proceed in 10 seconds. Press CTRL-C to cancel."
-sleep 10
+#echo "Warning: This script reportedly breaks recent version of Opera browser. Proceed with caution."
+#echo "However, files are backed up before changing, so you can always restore"
+#echo "Script will automatically proceed in 10 seconds. Press CTRL-C to cancel."
+#sleep 10
 
 # default installation path of Opera using their .deb file
 OPERA_PATH="${1:-/usr/lib/x86_64-linux-gnu/opera}"

--- a/opera-fix-ffmpeg.sh
+++ b/opera-fix-ffmpeg.sh
@@ -6,7 +6,8 @@ echo "However, files are backed up before changing, so you can always restore"
 echo "Script will automatically proceed in 10 seconds. Press CTRL-C to cancel."
 sleep 10
 
-OPERA_PATH="${1:-/usr/lib/opera}"
+# default installation path of Opera using their .deb file
+OPERA_PATH="${1:-/usr/lib/x86_64-linux-gnu/opera}"
 SNAP_BINARY="${2:-/usr/bin/snap}"
 
 validate_symlink() {
@@ -62,8 +63,8 @@ else
   "${SNAP_BINARY}" refresh chromium-ffmpeg
 fi
 
-LATEST_FFMPEG_VER="$(ls /snap/chromium-ffmpeg/current/ | grep -E '^chromium-ffmpeg-[[:digit:]]' | tail -1)"
-LATEST_FFMPEG_LIB="/snap/chromium-ffmpeg/current/${LATEST_FFMPEG_VER}/chromium-ffmpeg/libffmpeg.so"
+LATEST_FFMPEG_VER="$(ls /snap/chromium-ffmpeg/current/ | grep -E '^chromium-ffmpeg-[[:digit:]]'| awk -F- '{ print $3; }'|sort -n|tail -1)"
+LATEST_FFMPEG_LIB="/snap/chromium-ffmpeg/current/chromium-ffmpeg-${LATEST_FFMPEG_VER}/chromium-ffmpeg/libffmpeg.so"
 
 echo "Backing up original ${OPERA_PATH}/libffmpeg.so -> ${OPERA_PATH}/libffmpeg.so.bak"
 cp "${OPERA_PATH}/libffmpeg.so" "${OPERA_PATH}/libffmpeg.so.bak"


### PR DESCRIPTION
The minor changes to the lines that populate LATEST_FFMPEG_VER and LATEST_FFMPEG_LIB appear to fix the otherwise wrong selection of the library to link.
Tested on Pop!_OS 22.04 and on Ubuntu 22.04 with Opera 87.0.4390.25